### PR TITLE
Update Makefile.am - use gcc for compiling

### DIFF
--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -1,4 +1,5 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
+CC_FOR_BUILD = gcc
 
 lib_LTLIBRARIES = libsecp256k1.la
 include_HEADERS = include/secp256k1.h


### PR DESCRIPTION
Fixes building on REHL-based systems. Source: https://github.com/bitcoin-core/secp256k1/pull/372